### PR TITLE
Add ask-user message templates to agents and skills

### DIFF
--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -32,6 +32,7 @@ Execute these steps immediately on startup:
 
 If the diff scope is missing from your initialization context, ask your leader
 for it before proceeding. Do NOT review the entire codebase without a scope.
+Template: `"Need a diff scope: commit range, file paths, or branch name?"`
 
 ## Review Process
 

--- a/agents/junior-engineer.md
+++ b/agents/junior-engineer.md
@@ -57,7 +57,8 @@ Default model is `sonnet`. Leaders can override to `haiku` at dispatch time via 
 
 - **ALWAYS** follow the [oneteam:skill] `implementation` skill's Context Discovery and Verification phases.
 - **NEVER** deviate from the provided plan without asking first.
+  Template: `"This requires <out-of-scope change> not in the plan. Proceed or stay in scope?"`
 - **NEVER** begin implementation without confirming plan understanding.
 - **NEVER** work outside your assigned scope without asking first.
 - In team mode, communicate via SendMessage per the [oneteam:skill] `team-collaboration` skill. Do not write status to files expecting others to read them.
-- **ASK** if context is missing. Do not guess scope, task, or approach.
+- **ASK** if context is missing. Do not guess scope, task, or approach. (See [oneteam:skill] `implementation` skill for message templates.)

--- a/agents/lead-engineer.md
+++ b/agents/lead-engineer.md
@@ -54,6 +54,7 @@ Determine which domain to operate in based on your initialization context:
 
 If the context is ambiguous, ask your authority which domain applies before
 proceeding. Do NOT guess.
+Template: `"Context is ambiguous — feature or debug? Signals: <list>. Which domain?"`
 
 ---
 
@@ -71,6 +72,7 @@ Invoke the [oneteam:skill] **`spec-review`** skill. It will:
 
 If the spec is missing from your initialization context, ask your authority for
 it before proceeding. Do NOT guess or start without a spec.
+Template: `"No spec in my context. Please provide a spec, design doc path, or GitHub issue link."`
 
 ### Phase 2: Implementation Planning
 
@@ -120,6 +122,7 @@ With an approved spec, break it into concrete tasks and classify each.
 
 5. **Send plan to authority for approval.** Include classification rationale for
    borderline tasks.
+   Template: `"Implementation plan ready (<N> tasks: <M> junior, <K> senior). Approve to proceed?"`
 
 6. **HARD GATE: Wait for approval.** Do NOT proceed until the authority
    explicitly approves.

--- a/agents/researcher.md
+++ b/agents/researcher.md
@@ -28,6 +28,8 @@ When spawned, you receive initialization context that includes:
 
 If the question is missing or empty, ask the caller (or return with
 `ESCALATION NEEDED` flag in subagent mode).
+Template (team): `"Spawned without a research question. What should I investigate?"`
+Template (subagent): Return `**ESCALATION NEEDED** — no research question provided.`
 
 ## Workflow
 

--- a/agents/senior-engineer.md
+++ b/agents/senior-engineer.md
@@ -35,6 +35,7 @@ Run the [oneteam:skill] `implementation` skill's Context Discovery phase.
 1. Read the plan carefully.
 2. Identify anything unclear, ambiguous, or seemingly incorrect.
 3. Ask clarifying questions to your leader or the user.
+   Template: `"Questions before starting: 1. <question> 2. ..."`
 4. Once clarified, send the plan back to the leader/user for approval: `"I've reviewed the plan. Here's my understanding: <summary>. Ready to proceed?"`
 5. **WAIT** for explicit approval before moving to Phase 3.
 
@@ -46,6 +47,7 @@ Run the [oneteam:skill] `implementation` skill's Context Discovery phase.
    - Approach and rationale
    - Edge cases and risks considered
 2. Send the plan to the leader or user for approval.
+   Template: `"No plan provided. Here's my proposed approach: <plan>. Approve to proceed?"`
 3. **WAIT** for explicit approval before moving to Phase 3.
 
 **HARD GATE:** Do NOT begin implementation without plan approval. If approval is not received, wait. If rejected, revise the plan and resubmit.
@@ -75,5 +77,6 @@ Run the [oneteam:skill] `implementation` skill's Verification phase.
 - **ALWAYS** follow the [oneteam:skill] `implementation` skill's Context Discovery and Verification phases.
 - **NEVER** begin implementation without plan approval (Phase 2 hard gate).
 - **NEVER** work outside your assigned scope without asking first.
+  Template: `"This requires <out-of-scope change> not in the plan. Proceed or stay in scope?"`
 - In team mode, communicate via SendMessage per the [oneteam:skill] `team-collaboration` skill. Do not write status to files expecting others to read them.
-- **ASK** if context is missing. Do not guess scope, task, or approach.
+- **ASK** if context is missing. Do not guess scope, task, or approach. (See [oneteam:skill] `implementation` skill for message templates.)

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -22,7 +22,9 @@ You MUST create a task for each of these items and complete them in order:
 1. **Explore project context** — check files, docs, recent commits
 2. **Ask clarifying questions** — one at a time, understand purpose/constraints/success criteria
 3. **Propose 2-3 approaches** — with trade-offs and your recommendation
-4. **Present design** — in sections scaled to their complexity, get user approval after each section
+4. **Present design** — in sections scaled to their complexity, get user approval after each section.
+   After each section: `"Look right, or any changes?"`
+   After final section: `"Full design above. Approve to continue?"`
 5. **Choose working branch** — ask user which branch to work on via AskUserQuestion
 6. **Write design doc** — save to `docs/plans/YYYY-MM-DD-<topic>-design.md` (do NOT commit)
 7. **Offer GitHub issue posting** — optionally post the design to a GitHub issue
@@ -83,6 +85,13 @@ After writing the design file (and before invoking [oneteam:skill] `writing-plan
 if they want to post the design to a GitHub issue. If they decline, proceed
 directly to [oneteam:skill] `writing-plans`.
 
+Ask via `AskUserQuestion` (header: "GitHub issue"):
+
+| Option label | Description |
+|---|---|
+| Post to GitHub issue | Post design as a new or existing issue |
+| Skip | Go straight to planning |
+
 If they accept:
 
 1. **Ask which repository.** Always ask for the target repository. NEVER
@@ -92,11 +101,25 @@ If they accept:
    - `owner/repo` — target that specific repo
    - A full URL — extract the repo from it
 
+   Ask via `AskUserQuestion` (header: "Repository"):
+
+   | Option label | Description |
+   |---|---|
+   | This repo (`<owner/repo>`) | Current working directory's repo |
+   | Different repo | User types `owner/repo` or URL |
+
 2. **Ask new issue or existing.**
    - **New issue:** `gh issue create -R owner/repo --title "<topic>" --body "..."`
      Use the design topic as the title (e.g., "Add auth flow").
    - **Existing issue:** Ask for issue number, then
      `gh issue comment NUMBER -R owner/repo --body "..."`
+
+   Ask via `AskUserQuestion` (header: "Issue"):
+
+   | Option label | Description |
+   |---|---|
+   | New issue | Create with design topic as title |
+   | Existing issue | Comment on existing (user provides number) |
 
 3. **Always use the `-R` flag.** Never run `gh issue create` or
    `gh issue comment` without `-R owner/repo`. This prevents accidentally

--- a/skills/bug-hunting/SKILL.md
+++ b/skills/bug-hunting/SKILL.md
@@ -54,6 +54,7 @@ The agent defines the exact scope before reading any implementation code.
 
 If the user does not provide scope, the agent asks for it. The agent never
 assumes scope from context alone.
+Template: `"Need a scope to begin: PR numbers, file paths, module names, or a directory?"`
 
 ### Phase 2: Contract Inventory
 

--- a/skills/implementation/SKILL.md
+++ b/skills/implementation/SKILL.md
@@ -29,11 +29,14 @@ If any of the following are missing from your initialization context, ask your l
 - **Scope** — what files/modules/area to work on
 - **Task description** — what to do (fix a bug, add a feature, etc.)
 
+Template: `"Blocked — missing <scope / task description / both>. What I have: <what was provided>. Can you clarify?"`
+
 ## Phase 1: Context Discovery
 
 1. Scan the scope area to understand the relevant code.
 2. Identify the test framework, build system, and test commands.
 3. If scope or task is unclear, ask for clarification. Do NOT guess.
+   Template: `"Unsure whether <ambiguity>. Should I <option A> or <option B>?"`
 
 ## Common Best Practices
 
@@ -81,5 +84,6 @@ When you receive code review feedback, use the [superpowers:skill] `receiving-co
 - **ALWAYS** run Phase 1 (Context Discovery), even when using a skill directive.
 - **ALWAYS** run Phase 2 (Verification) after completing work.
 - **NEVER** work outside your assigned scope without asking first.
+  Template: `"This requires <out-of-scope change> not in the plan. Proceed or stay in scope?"`
 - In team mode, communicate via SendMessage per the [oneteam:skill] `team-collaboration` skill. Do not write status to files expecting others to read them.
-- **ASK** if context is missing. Do not guess scope, task, or approach.
+- **ASK** if context is missing. Do not guess scope, task, or approach. (See Startup Protocol above for message templates.)

--- a/skills/spec-review/SKILL.md
+++ b/skills/spec-review/SKILL.md
@@ -24,6 +24,7 @@ any implementation planning begins.
 1. **Obtain the spec.** Read the specification from the initialization context,
    authority message, or user prompt. If no spec is available, ask the authority
    for it before proceeding. Do NOT guess or start without a spec.
+   Template: `"Need the spec to begin review. Please provide it or point me to the design doc."`
 
 2. **Read it end-to-end.** Read the entire spec thoroughly before analyzing.
    Do not start identifying issues mid-read — complete the full read first to
@@ -114,6 +115,7 @@ If a section has no items, write "None" rather than omitting the section.
 
 **Send to authority for approval.** Via SendMessage if in a team, or display
 to user if standalone. Include the full report.
+Template: `"Spec review complete. Blocked on answers to <Q1, Q2, ...>. Please confirm the spec to proceed."`
 
 ## Phase 6: Hard Gate — Wait for Approval
 

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -82,6 +82,13 @@ makes the final choice.
 
 2. **User picks strategy.** Wait for the user to choose `subagent` or `team`.
 
+   Ask via `AskUserQuestion` (header: "Strategy"):
+
+   | Option label | Description |
+   |---|---|
+   | Subagent-driven | Sequential execution, fresh subagent per task |
+   | Team-driven | Parallel agents with worktrees |
+
 3. **HARD GATE.** Do NOT proceed to Phase 3 until the user has explicitly
    chosen a strategy.
 


### PR DESCRIPTION
## Summary

- Added 19 concise message templates across 10 files where agents/skills were told to "ask the user" but had no template for what to say
- Templates grouped into 5 clusters: missing context (implementation skill), missing spec/approval (lead-engineer, spec-review), other agent asks (researcher, senior-engineer, code-reviewer, bug-hunting), brainstorming sub-questions (AskUserQuestion tables), and writing-plans strategy pick
- Added cross-references from junior-engineer and senior-engineer constraint sections back to the canonical implementation skill templates

## Test plan

- [ ] Verify templates render correctly in markdown
- [ ] Spot-check that each template is placed adjacent to the instruction it serves
- [ ] Confirm no existing behavior or templates were removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)