### PR TITLE
docs: add skill usage guide with decision tree and scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ you commit to implementation.
 | Scenario | Skill | What happens |
 |----------|-------|--------------|
 | "Tests are failing with this error message" | systematic-debugging\* | Structured debugging: reproduce, hypothesize, isolate, fix, verify |
-| "I suspect there are bugs in the auth module but nothing is failing yet" | bug-hunting | 6-phase audit: scope, contracts, impact tracing, adversarial analysis, gap analysis |
+| "I suspect there are bugs in the auth module but nothing is failing yet" | bug-hunting | 6-phase audit: scope, contracts, impact tracing, adversarial analysis, gap analysis, shallow verification & report |
 | "Full codebase debug sweep after a big refactor" | team-management | Spawns bug-hunter + engineer pairs, coordinates fixes |
 
 **Research & Planning**


### PR DESCRIPTION
## Summary

- Adds a "When to Use Which Skill" reference section to README.md with an ASCII decision tree and scenario-based examples
- Covers 3 user intent paths (build, debug, research) mapped to 8 skills across 10 concrete scenarios
- Marks superpowers-dependent skills (`subagent-driven-development`, `systematic-debugging`) with `*` notation and footnote

## Test plan

- [ ] Verify README renders correctly on GitHub (decision tree in code block, tables aligned)
- [ ] Confirm all 8 skill names are accurate and link to real skills
- [ ] Check section placement (before Requirements, after Usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)